### PR TITLE
Add ability to specify auth token to tus_client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tus_client"
-version = "0.1.1" # remember to update html_root_url
+version = "0.2.0" # remember to update html_root_url
 authors = ["Jon Grythe Stødle <jonstodle@outlook.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
Example usage:
    use tus_client::Client;
.
.
    let token = var("TOKEN").unwrap();
    let client = Client::new(reqwest::Client::new()).with_auth_token(token);